### PR TITLE
fix: add rnds config to provider config

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -64,6 +64,7 @@ function seifWallet(): Wallet {
         "https://chromewebstore.google.com/detail/seif/albakdmmdafeafbehmcpoejenbeojejl",
     },
     createConnector: createInjectedConnector(injectedProvider),
+    rdns: "com.passkeywallet.seif",
   };
 }
 


### PR DESCRIPTION
When the rdns value is set, and the self-extension is installed, it will be excluded from the recommendation group. If it is not installed, it will be exposed in the recommendation group as expected.